### PR TITLE
Add operant-mcp — security testing server with 51 tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -114,6 +114,8 @@ March 22, 2026 at 02:49:23 AM UTC
 - [WritBase](https://github.com/Writbase/writbase) - MCP-native task management for AI agent fleets. Multi-agent permissions, full provenance, inter-agent task delegation, and A2A protocol alignment.
 - [Roundtable](https://github.com/sinaneshat/roundtable-dashboard) - Multi-model AI brainstorming MCP server — consult a council of AI models that debate your question, then a moderator synthesizes the best answer. 13 tools including consult_council, review_code, debug_issue, design_architecture, plan_implementation, and assess_tradeoffs. Remote endpoint: `https://mcp.roundtable.now/mcp`.
 
+- [operant-mcp](https://github.com/operantlabs/operant-mcp) - Security testing MCP server with 51 tools for penetration testing, network forensics, memory analysis, and vulnerability assessment. Install via `npx operant-mcp`.
+
 ## Tutorial
 
 ### Written Tutorials


### PR DESCRIPTION
## Summary

Adds [operant-mcp](https://github.com/operantlabs/operant-mcp) to the **Library** section.

**operant-mcp** is a security testing MCP server with 51 tools covering:
- Penetration testing (SQL injection, XSS, SSRF, command injection, etc.)
- Network forensics (PCAP analysis, DNS analysis, TLS inspection)
- Memory analysis (Linux/Windows volatility, rootkit detection)
- Vulnerability assessment (file upload testing, deserialization, GraphQL introspection)

Install via `npx operant-mcp`.

## Changes

- Added operant-mcp entry to the Library section in readme.md