### PR TITLE
Add operant-mcp to Library section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -113,6 +113,7 @@ March 22, 2026 at 02:49:23 AM UTC
 
 - [WritBase](https://github.com/Writbase/writbase) - MCP-native task management for AI agent fleets. Multi-agent permissions, full provenance, inter-agent task delegation, and A2A protocol alignment.
 - [Roundtable](https://github.com/sinaneshat/roundtable-dashboard) - Multi-model AI brainstorming MCP server — consult a council of AI models that debate your question, then a moderator synthesizes the best answer. 13 tools including consult_council, review_code, debug_issue, design_architecture, plan_implementation, and assess_tradeoffs. Remote endpoint: `https://mcp.roundtable.now/mcp`.
+- [operant-mcp](https://github.com/operantlabs/operant-mcp) - Security testing MCP server with 51 tools for penetration testing, network forensics, memory analysis, and vulnerability assessment.
 
 ## Tutorial
 


### PR DESCRIPTION
## Summary
- Adds [operant-mcp](https://github.com/operantlabs/operant-mcp) to the Library section
- Security testing MCP server with 51 tools for penetration testing, network forensics, memory analysis, and vulnerability assessment
- TypeScript, MIT license