### PR TITLE
Add TensorFeed MCP to Library

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -137,6 +137,7 @@ May 7, 2026 at 03:44:54 AM UTC
 - [WritBase](https://github.com/Writbase/writbase) - MCP-native task management for AI agent fleets. Multi-agent permissions, full provenance, inter-agent task delegation, and A2A protocol alignment.
 - [Roundtable](https://github.com/sinaneshat/roundtable-dashboard) - Multi-model AI brainstorming MCP server — consult a council of AI models that debate your question, then a moderator synthesizes the best answer. 13 tools including consult_council, review_code, debug_issue, design_architecture, plan_implementation, and assess_tradeoffs. Remote endpoint: `https://mcp.roundtable.now/mcp`.
 - [operant-mcp](https://github.com/operantlabs/operant-mcp) - Security testing MCP server with 51 tools for penetration testing, network forensics, memory analysis, and vulnerability assessment.
+- [TensorFeed MCP](https://github.com/RipperMercs/tensorfeed-mcp) - Real-time AI ecosystem data MCP server with 42 tools: AI news from 50+ sources, model pricing, AI service status (Claude/OpenAI/Gemini), MCP registry growth, GitHub trending, AI papers. 8 free tools plus 14 premium x402 pay-per-call tools (routing, history series, news search, cost projection, recession watch) in USDC on Base. AFTA-certified. Listed in the official MCP Registry as `ai.tensorfeed/mcp-server`.
 
 ## Tutorial
 


### PR DESCRIPTION
## What

Adds [TensorFeed MCP](https://github.com/RipperMercs/tensorfeed-mcp) (npm: `@tensorfeed/mcp-server`) to the Library section.

## TensorFeed MCP

Real-time AI ecosystem data MCP server. 42 tools, all read-only and idempotent with annotations.

**Free (no token):** AI news (50+ sources), model pricing across major labs, AI service status (Claude, OpenAI, Gemini, Grok, etc), is-service-down checks, MCP registry growth, GitHub trending, npm/PyPI AI package trending, arXiv + Semantic Scholar + HF Daily papers, agent traffic on tensorfeed.ai itself, model deprecations.

**Premium (USDC on Base via x402, 1-3 credits ~$0.02-0.06 each):** routing recommendations, multi-day pricing/benchmark/status/uptime time series, leaderboard rankings, agents directory, what's-new digest, model comparison, provider deep-dives, news search, cost projection, recession watch, MCP registry growth series, webhook watches.

## Listings

- Official MCP Registry: `ai.tensorfeed/mcp-server`
- npm: [`@tensorfeed/mcp-server`](https://www.npmjs.com/package/@tensorfeed/mcp-server)
- Repo (public): https://github.com/RipperMercs/tensorfeed-mcp
- Site: https://tensorfeed.ai

## AFTA

Covered by the [Agent Fair-Trade Agreement](https://tensorfeed.ai/agent-fair-trade) standard: code-enforced no-charge guarantees on 5xx, breaker, schema validation failure, or stale data. Every paid call returns an Ed25519-signed receipt verifiable at `/api/receipt/verify`.