### PR TITLE
Add AccInt to Library

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -146,6 +146,7 @@ June 15, 2026 at 05:04:52 AM UTC
 
 ## Library
 
+- [AccInt](https://github.com/maxbaluev/accreted-intelligence) - Local-first Work Model and MCP server for coding-agent memory across Claude Code, OpenCode, Codex, and Cursor. Uses a SQLite-backed memory substrate and verified outcome feedback. [Homepage](https://accint.xyz/) | Public integration glue with private engine.
 - [WritBase](https://github.com/Writbase/writbase) - MCP-native task management for AI agent fleets. Multi-agent permissions, full provenance, inter-agent task delegation, and A2A protocol alignment.
 - [Roundtable](https://github.com/sinaneshat/roundtable-dashboard) - Multi-model AI brainstorming MCP server — consult a council of AI models that debate your question, then a moderator synthesizes the best answer. 13 tools including consult_council, review_code, debug_issue, design_architecture, plan_implementation, and assess_tradeoffs. Remote endpoint: `https://mcp.roundtable.now/mcp`.
 - [operant-mcp](https://github.com/operantlabs/operant-mcp) - Security testing MCP server with 51 tools for penetration testing, network forensics, memory analysis, and vulnerability assessment.


### PR DESCRIPTION
## Summary

Adds AccInt to the Library section.

AccInt is a local-first Work Model and MCP server for coding-agent memory across Claude Code, OpenCode, Codex, and Cursor. It uses a SQLite-backed memory substrate and verified outcome feedback.

## Notes

The entry links both the public repository and homepage, and explicitly notes the public integration glue / private engine boundary.

## Validation

- `git diff --check`
- Checked `https://accint.xyz/` and `https://github.com/maxbaluev/accreted-intelligence` return HTTP 200
