### PR TITLE
Add Xquik MCP to Library

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -157,6 +157,7 @@ June 28, 2026 at 04:23:23 AM UTC
 - [WritBase](https://github.com/Writbase/writbase) - MCP-native task management for AI agent fleets. Multi-agent permissions, full provenance, inter-agent task delegation, and A2A protocol alignment.
 - [Roundtable](https://github.com/sinaneshat/roundtable-dashboard) - Multi-model AI brainstorming MCP server — consult a council of AI models that debate your question, then a moderator synthesizes the best answer. 13 tools including consult_council, review_code, debug_issue, design_architecture, plan_implementation, and assess_tradeoffs. Remote endpoint: `https://mcp.roundtable.now/mcp`.
 - [operant-mcp](https://github.com/operantlabs/operant-mcp) - Security testing MCP server with 51 tools for penetration testing, network forensics, memory analysis, and vulnerability assessment.
+- [Xquik MCP](https://github.com/Xquik-dev/x-twitter-scraper) - Remote MCP server for X data search, user lookup, and trends. Remote endpoint: `https://xquik.com/mcp`.
 
 ## Tutorial
 


### PR DESCRIPTION
Summary:
- Add Xquik MCP to the Library section as a remote MCP server for X search, user lookup, and trends.

Validation:
- git diff --check
- node --check parser/readme.js
- Verified https://xquik.com/.well-known/mcp.json advertises https://xquik.com/mcp with an Authorization header.
- Verified https://github.com/Xquik-dev/x-twitter-scraper resolves.
